### PR TITLE
[Updated] Small improvements in splash screen loading

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -10,7 +10,7 @@
         <item name="android:windowBackground">@color/colorPrimary</item>
     </style>
 
-    <style name="SplashTheme" parent="Theme.AppCompat.NoActionBar">
+    <style name="SplashTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="android:background">@color/colorPrimary</item>
         <item name="android:windowFullscreen">true</item>
     </style>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -10,7 +10,8 @@
         <item name="android:windowBackground">@color/colorPrimary</item>
     </style>
 
-    <style name="SplashTheme" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="SplashTheme" parent="Theme.AppCompat.NoActionBar">
+        <item name="android:background">@color/colorPrimary</item>
         <item name="android:windowFullscreen">true</item>
     </style>
 


### PR DESCRIPTION
You had `AppCompat.Light` theme for your Splash screen which when launched shows a white background color before Android draws your splash layout. 

This doesn't look satisfying, so I tweaked this theme and changed the theme's background color to the splash screen background.

PS: I could've open this PR against the `development` branch but saw it is not up-to-date with the `master` branch. Hence, opened PR against the `master` branch.